### PR TITLE
Added support for the attachment type

### DIFF
--- a/challonge/account.py
+++ b/challonge/account.py
@@ -7,6 +7,7 @@ import asyncio
 from challonge.tournaments import Tournaments
 from challonge.participants import Participants
 from challonge.matches import Matches
+from challonge.attachments import Attachments
 
 try:
     from xml.etree import cElementTree as ElementTree
@@ -29,6 +30,7 @@ class Account():
         self._tournaments = Tournaments(self)
         self._participants = Participants(self)
         self._matches = Matches(self)
+        self._attachments = Attachments(self)
         self._loop = loop or asyncio.get_event_loop()
         self._session = aiohttp.ClientSession(loop=self._loop)
         self.timeout = timeout
@@ -47,6 +49,10 @@ class Account():
     @property
     def matches(self):
         return self._matches
+
+    @property
+    def attachments(self):
+        return self._attachments
 
     @property
     async def is_valid(self):

--- a/challonge/attachments.py
+++ b/challonge/attachments.py
@@ -1,0 +1,36 @@
+class Attachments():
+    def __init__(self, account):
+        self._account = account
+
+    def attachment_url(self, tournament, match):
+        return "tournaments/{}/matches/{}/attachments".format(tournament, match)
+
+    async def index(self, tournament, match, **params):
+        """Retrieve a set of attachments associated with a match."""
+        return await self._account.fetch_and_parse("GET", self.attachment_url(tournament, match), **params)
+
+    async def create(self, tournament, match, description='', asset='', url='', **params):
+        """Create a new attachment."""
+        # @TODO: Support a file upload here explicitly. Not sure how
+        params.update({
+            "asset": asset,
+            "url": url,
+            "description": description
+        });
+        return await self._account.fetch_and_parse("POST", self.attachment_url(tournament, match), "match_attachment", **params)
+
+    async def show(self, tournament, match, attachment, **params):
+        """Retrieve a single attachment record created with your account."""
+        return await self._account.fetch_and_parse("GET", self.attachment_url(tournament, match) + "/%s" % attachment, **params)
+
+    async def update(self, tournament, match, attachment, **params):
+        """Retrieve a single attachment record created with your account."""
+        return await self._account.fetch_and_parse("PUT", self.attachment_url(tournament, match) + "/%s" % attachment, **params)
+
+    async def destroy(self, tournament, match, attachment):
+        """Deletes a attachment along with all its associated records.
+
+        There is no undo, so use with care!
+
+        """
+        await self._account.fetch("DELETE", self.attachment_url(tournament, match) + "/%s" % attachment)


### PR DESCRIPTION
Tests pass, also snuck in a little fix for the matches test which was failing on my machine anyway....  I have not tested sending an actual file to this.  I honestly don't know enough about aiohttp to know how it would handle that and it is isn't in my usecase so I'm not going to spend time on it right now.  But this is better than nothing and does handle basic URL and text attachment functionality.

